### PR TITLE
Comment out JavaScript/TypeScript in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,8 +45,8 @@ jobs:
         include:
         - language: python
           build-mode: none
-        - language:  javascript-typescript
-          build-mode: none
+        # - language:  javascript-typescript
+        #  build-mode: none
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
removing javascript as language